### PR TITLE
Updates to make it work with latest seneca-mail and postmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# IDE
+.idea
+.vscode
+
+# OS X
+.DS_Store
+
 lib-cov
 *.seed
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.10
+  - "4"

--- a/lib/postmark.js
+++ b/lib/postmark.js
@@ -1,22 +1,17 @@
 /* Copyright (c) 2013 Richard Rodger, MIT License */
 "use strict";
 
-
 var _              = require('underscore')
 var postmark       = require("postmark");
 
 var name = "postmark-mail"
 
-
-
-
-
-module.exports = function( options, register ){
+module.exports = function( options ){
+  var postmarkinstance = new postmark.Client( options.key )
   var seneca = this
 
   options = this.util.deepextend({
   },options)
-
 
   var aliasmap = {
     'from':    'From',
@@ -41,29 +36,23 @@ module.exports = function( options, register ){
     return out
   }
 
-
   seneca.add({role:'mail',hook:'send'},function( args, done ){
 
     var mailoptions = _.extend({}, options, args)
 
     mailoptions = postmarkaliases(mailoptions)
 
-    postmarkinstance.send( mailoptions, function( err, out) {
-      if( err ) return done(err);
+    postmarkinstance.sendEmail( mailoptions, function( err, out) {
+      if( err ) {
+        return done(err);
+      }
       done(null,{ok:true,details:out})
     })
   })
 
-
-
-  var postmarkinstance
-
   seneca.add({role:'mail',hook:'init',sub:'transport'},function( args, done ){
-    postmarkinstance = postmark( options.key )
     done(null)
   })
 
-
-  register(null,{name:name})
+  return {name:name}
 }
-

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "seneca": "~0.5.x",
-    "seneca-mail": "~0.1.x"
+    "seneca": "2.1.0",
+    "seneca-mail": "0.2.2"
   },
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-postmark-mail",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Seneca postmarkapp.com email plugin",
   "main": "lib/postmark.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "author": "Richard Rodger (http://richardrodger.com)",
   "license": "MIT",
   "dependencies": {
-    "underscore": "~1.4.4",
-    "postmark": "~0.1.8"
+    "postmark": "1.2.1",
+    "underscore": "1.8.3"
   },
   "devDependencies": {
     "seneca": "~0.5.x",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "plugin"
   ],
   "author": "Richard Rodger (http://richardrodger.com)",
+  "contributors": [
+    "Geir Gåsodden (https://github.com/zrrrzzt)"
+  ],
   "license": "MIT",
   "dependencies": {
     "postmark": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "seneca": "3.2.2",
+    "seneca": "3.3.0",
     "seneca-mail": "0.2.2"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "postmark": "1.2.1",
+    "postmark": "1.3.1",
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "seneca": "2.1.0",
+    "seneca": "3.2.2",
     "seneca-mail": "0.2.2"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "postmark": "1.3.1",
-    "underscore": "1.8.3"
+    "underscore": "1.9.0"
   },
   "devDependencies": {
     "seneca": "3.3.0",


### PR DESCRIPTION
Given this is listed as an example plugin for [seneca-mail](https://github.com/rjrodger/seneca-mail) I thought it would be nice if it worked out of the box :-)

Changes:
- match the new plugin signature in Seneca
- updates dependencies and dev-dependencies
- updates to work with latest module from postmark
- updates node to 4 in .travis.yml
